### PR TITLE
move to viz.js from native graphviz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 npm-debug.log
 tmp
-test/schema.png
+test/schema.svg

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
     graphviz: {
       schema: {
         files: {
-          './test/schema.png': './test/schema.dot'
+          './test/schema.svg': './test/schema.dot'
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.1"
+    "grunt": "^0.4.5",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-nodeunit": "^1.0.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"
@@ -43,5 +43,8 @@
     "graphviz",
     "graph",
     "visualization"
-  ]
+  ],
+  "dependencies": {
+    "viz.js": "^1.3.0"
+  }
 }

--- a/tasks/graphviz.js
+++ b/tasks/graphviz.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+var Viz = require('viz.js');
+
 module.exports = function(grunt) {
     var path            = require('path');
     var fs              = require('fs');
@@ -19,7 +21,7 @@ module.exports = function(grunt) {
     grunt.registerMultiTask('graphviz', 'Compile DOT files', function() {
         // Merge task-specific and/or target-specific options with these defaults.
         var options = this.options();
-        var formats = 'bmp canon cgimage cmap cmapx cmapx_np dot eps exr fig gd gd2 gif gv imap imap_np ismap jp2 jpe jpeg jpg pct pdf pic pict plain plain-ext png pov ps ps2 psd sgi svg svgz tga tif tiff tk vml vmlz vrml wbmp webp x11 xdot xlib'.split(' ');
+        var formats = ['svg', 'xdot', 'plain', 'ps'];
 
         grunt.verbose.writeflags(options, 'Options');
 
@@ -63,19 +65,10 @@ module.exports = function(grunt) {
                 if (dest !== src && grunt.file.exists(dest)) {
                     grunt.file.delete(dest);
                 }
-
-                cp = grunt.util.spawn({
-                    cmd: 'dot',
-                    args: [
-                        '-T' + format,
-                        src,
-                        '-o',
-                        dest
-                    ],
-                    opts: {
-                        stdio: 'inherit'
-                    }
-                }, processed);
+                var file = grunt.file.read(src);
+                var output = Viz(file, {format: format});
+                grunt.file.write(dest, output);
+                processed();
             }
 
         }


### PR DESCRIPTION
this allows you to have no native dependencies. 

restricts severely the amount the formats that are accepted. 
